### PR TITLE
Added Korean Language translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Ever raised a Tallbird? Probably not because in the base game raised Tallbirds a
 曾经养过高脚鸟吗？在基本游戏中饲养的高脚鸟是敌对的，没有多少用处。 ”驯服高脚鸟”试图通过解决这个问题,让玩家养成的高脚鸟成为忠实的宠物和战友。
 注意：中文需要启用中文字体修改，例如 [url=http://steamcommunity.com/sharedfiles/filedetails/?id=874857181]Chinese中文支持[/url].
 
+큰 새가 키운 적이 있습니까? 아마도베이스 게임에서 키 큰 새들이 적대적이며별로 사용하지 않기 때문일 것입니다. 재배된 큰 새를 사용하면 키 큰 새들을 충성도가 높은 애완 동물이나 잠재적 인 전투원으로 키울 수 있습니다.
+
 Tame Tallbirds:
 [list]
 [*] Have similar combat stats to wild Tallbirds

--- a/mod/modinfo.lua
+++ b/mod/modinfo.lua
@@ -122,6 +122,7 @@ configuration_options =
             {description = "中文", data = "zh"},
             {description = "繁體中文", data = "zh-TM"},
             {description = "English", data = "en-us"},
+            {description = "한국어", data = "ko"},
             {description = "русский", data = "ru"},
         },
         default = "en-us",

--- a/mod/scripts/lang/ko.lua
+++ b/mod/scripts/lang/ko.lua
@@ -1,22 +1,22 @@
 return {
     -- Display name of the tame birds
-    TAMETALLBIRD_NAME = "Tame Tallbird",
+    TAMETALLBIRD_NAME = "재배된 큰 새",
     TAMETALLBIRD_DESCRIBE = {
         -- Birds are friendly when well fed
-        FULL = "Surprisingly friendly with a full stomach.",
+        FULL = "잘 먹었을 때 친절 함.",
         -- Generic inspect string for the bird
-        GENERIC = "Very tall and very loyal.",
+        GENERIC = "매우 크고 매우 충성.",
         -- Bird is hungry and needs food
-        HUNGRY = "Better get you some food, Big Guy.",
+        HUNGRY = "너 한테 음식 좀 가져다 줄 게, 빅 가이.",
         -- Bird is hungry and might attack the player
-        STARVING = "Careful Big Guy, just don't eat me!",
+        STARVING = "조심성 있는 빅 가이, 그냥 날 먹지 마!",
         -- Bird is asleep
-        SLEEPING = "Curiously docile.",
+        SLEEPING = "기묘하게 온순한.",
     },
     STAY_ACTION = {
         -- Display name for Right-Click "Stay" action
-        NAME = "Stay",
+        NAME = "머무르다",
         -- Spoken command to a pet to "Stay here"
-        ANNOUNCE = "Stay here!",
+        ANNOUNCE = "여기서 기다려.",
     },
 }

--- a/mod/scripts/lang/ko.lua
+++ b/mod/scripts/lang/ko.lua
@@ -1,0 +1,22 @@
+return {
+    -- Display name of the tame birds
+    TAMETALLBIRD_NAME = "Tame Tallbird",
+    TAMETALLBIRD_DESCRIBE = {
+        -- Birds are friendly when well fed
+        FULL = "Surprisingly friendly with a full stomach.",
+        -- Generic inspect string for the bird
+        GENERIC = "Very tall and very loyal.",
+        -- Bird is hungry and needs food
+        HUNGRY = "Better get you some food, Big Guy.",
+        -- Bird is hungry and might attack the player
+        STARVING = "Careful Big Guy, just don't eat me!",
+        -- Bird is asleep
+        SLEEPING = "Curiously docile.",
+    },
+    STAY_ACTION = {
+        -- Display name for Right-Click "Stay" action
+        NAME = "Stay",
+        -- Spoken command to a pet to "Stay here"
+        ANNOUNCE = "Stay here!",
+    },
+}


### PR DESCRIPTION
Base English translation is here: [English](https://github.com/brisberg/TameTallbirds/blob/lang-spanish/mod/scripts/lang/en-us.lua)

"큰 새" was selected for "Tallbird" to match the official language pack.

Attack Tallbird:
![korean_tallbird](https://user-images.githubusercontent.com/287146/28495059-5402c806-6ef6-11e7-9406-6ab7334a7784.png)
